### PR TITLE
basic認証の一時停止

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,16 +1,16 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth, if: :production?
-  protect_from_forgery with: :exception
+  # before_action :basic_auth, if: :production?
+  # protect_from_forgery with: :exception
 
-  private
+  # private
 
-  def production?
-    Rails.env.production?
-  end
+  # def production?
+    # Rails.env.production?
+  # end
 
-  def basic_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
-    end
-  end
+  # def basic_auth
+    # authenticate_or_request_with_http_basic do |username, password|
+      # username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    # end
+  # end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -62,6 +62,6 @@
 
 server '54.92.74.40', user: 'ec2-user', roles: %w{app db web}
 
-set :rails_env, "production"
-set :unicorn_rack_env, "production"
+# set :rails_env, "production"
+# set :unicorn_rack_env, "production"
 


### PR DESCRIPTION
# WHAT
basic認証の一時停止

# WHY
本番環境において、指定のユーザーID, passwordを入力してもログインできない。
スプリントレビュー後に、改めて実装するため。