### PR TITLE
各モデルの外部キー削除

### DIFF
--- a/db/migrate/20190615045547_create_profiles.rb
+++ b/db/migrate/20190615045547_create_profiles.rb
@@ -9,7 +9,7 @@ class CreateProfiles < ActiveRecord::Migration[5.2]
       t.integer :birthday_year
       t.integer :birthday_month
       t.integer :bithday_day
-      t.references :user, foreign_key:true
+      # t.references :user, foreign_key:true
 
       t.timestamps
     end

--- a/db/migrate/20190615045619_create_addresses.rb
+++ b/db/migrate/20190615045619_create_addresses.rb
@@ -7,7 +7,7 @@ class CreateAddresses < ActiveRecord::Migration[5.2]
       t.string :address
       t.string :building
       t.integer :phone
-      t.references :user, foreign_key:true
+      # t.references :user, foreign_key:true
 
       t.timestamps
     end

--- a/db/migrate/20190615045632_create_items.rb
+++ b/db/migrate/20190615045632_create_items.rb
@@ -13,10 +13,10 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.integer :tax
       t.integer :profit
       t.integer :status
-      t.references :user, foreign_key:true
-      t.references :brand, foreign_key:true
-      t.references :small_category, foreign_key:true
-      t.references :size, foreign_key:true
+      # t.references :user, foreign_key:true
+      # t.references :brand, foreign_key:true
+      # t.references :small_category, foreign_key:true
+      # t.references :size, foreign_key:true
 
       t.timestamps
     end

--- a/db/migrate/20190615045643_create_comments.rb
+++ b/db/migrate/20190615045643_create_comments.rb
@@ -2,8 +2,8 @@ class CreateComments < ActiveRecord::Migration[5.2]
   def change
     create_table :comments do |t|
       t.string :text
-      t.references :user, foreign_key:true
-      t.references :item, foreign_key:true
+      # t.references :user, foreign_key:true
+      # t.references :item, foreign_key:true
 
       t.timestamps
     end

--- a/db/migrate/20190615045656_create_evaluations.rb
+++ b/db/migrate/20190615045656_create_evaluations.rb
@@ -3,8 +3,8 @@ class CreateEvaluations < ActiveRecord::Migration[5.2]
     create_table :evaluations do |t|
       t.string :evaluation
       t.integer :date
-      t.references :user, foreign_key:true
-      t.references :transaction, foreign_key:true
+      # t.references :user, foreign_key:true
+      # t.references :transaction, foreign_key:true
 
       t.timestamps
     end

--- a/db/migrate/20190615050454_create_transactions.rb
+++ b/db/migrate/20190615050454_create_transactions.rb
@@ -1,9 +1,9 @@
 class CreateTransactions < ActiveRecord::Migration[5.2]
   def change
     create_table :transactions do |t|
-      t.references :item, foreign_key:true
-      t.references :buyer, foreign_key:true
-      t.references :seller, foreign_key:true
+      # t.references :item, foreign_key:true
+      # t.references :buyer, foreign_key:true
+      # t.references :seller, foreign_key:true
 
       t.timestamps
     end

--- a/db/migrate/20190615050502_create_likes.rb
+++ b/db/migrate/20190615050502_create_likes.rb
@@ -1,8 +1,8 @@
 class CreateLikes < ActiveRecord::Migration[5.2]
   def change
     create_table :likes do |t|
-      t.references :user, foreign_key:true
-      t.references :item, foreign_key:true
+      # t.references :user, foreign_key:true
+      # t.references :item, foreign_key:true
 
       t.timestamps
     end

--- a/db/migrate/20190615050514_create_credits.rb
+++ b/db/migrate/20190615050514_create_credits.rb
@@ -5,7 +5,7 @@ class CreateCredits < ActiveRecord::Migration[5.2]
       t.string :expiration_date_month
       t.string :expiration_date_year
       t.string :security_code
-      t.references :user, foreign_key:true
+      # t.references :user, foreign_key:true
 
       t.timestamps
     end

--- a/db/migrate/20190615050532_create_images.rb
+++ b/db/migrate/20190615050532_create_images.rb
@@ -2,7 +2,7 @@ class CreateImages < ActiveRecord::Migration[5.2]
   def change
     create_table :images do |t|
       t.string :image
-      t.references :item, foreign_key:true
+      # t.references :item, foreign_key:true
 
       t.timestamps
     end

--- a/db/migrate/20190615050607_create_brands.rb
+++ b/db/migrate/20190615050607_create_brands.rb
@@ -2,7 +2,7 @@ class CreateBrands < ActiveRecord::Migration[5.2]
   def change
     create_table :brands do |t|
       t.string :name
-      t.references :brands_group, foreign_key:true
+      # t.references :brands_group, foreign_key:true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,10 +27,8 @@ ActiveRecord::Schema.define(version: 2019_06_15_050618) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
-    t.bigint "brands_group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["brands_group_id"], name: "index_brands_on_brands_group_id"
   end
 
   create_table "brands_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -41,12 +39,8 @@ ActiveRecord::Schema.define(version: 2019_06_15_050618) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "text"
-    t.bigint "user_id"
-    t.bigint "item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["item_id"], name: "index_comments_on_item_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "credits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -54,29 +48,21 @@ ActiveRecord::Schema.define(version: 2019_06_15_050618) do
     t.string "expiration_date_month"
     t.string "expiration_date_year"
     t.string "security_code"
-    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_credits_on_user_id"
   end
 
   create_table "evaluations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "evaluation"
     t.integer "date"
-    t.bigint "user_id"
-    t.bigint "transaction_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["transaction_id"], name: "index_evaluations_on_transaction_id"
-    t.index ["user_id"], name: "index_evaluations_on_user_id"
   end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "image"
-    t.bigint "item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["item_id"], name: "index_images_on_item_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -92,25 +78,13 @@ ActiveRecord::Schema.define(version: 2019_06_15_050618) do
     t.integer "tax"
     t.integer "profit"
     t.integer "status"
-    t.bigint "user_id"
-    t.bigint "brand_id"
-    t.bigint "small_category_id"
-    t.bigint "size_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["brand_id"], name: "index_items_on_brand_id"
-    t.index ["size_id"], name: "index_items_on_size_id"
-    t.index ["small_category_id"], name: "index_items_on_small_category_id"
-    t.index ["user_id"], name: "index_items_on_user_id"
   end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["item_id"], name: "index_likes_on_item_id"
-    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -135,19 +109,15 @@ ActiveRecord::Schema.define(version: 2019_06_15_050618) do
   end
 
   create_table "transactions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "item_id"
-    t.bigint "buyer_id"
-    t.bigint "seller_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["buyer_id"], name: "index_transactions_on_buyer_id"
-    t.index ["item_id"], name: "index_transactions_on_item_id"
-    t.index ["seller_id"], name: "index_transactions_on_seller_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.string "nickname"
+    t.text "avater_image"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -169,4 +139,6 @@ ActiveRecord::Schema.define(version: 2019_06_15_050618) do
     t.index ["reset_password_token"], name: "index_views_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "addresses", "users"
+  add_foreign_key "profiles", "users"
 end


### PR DESCRIPTION
# WHAT
各モデルの外部キー削除

# WHY
各モデルを一括でデプロイすると外部キーでエラーが発生する。外部キー削除の状態でデプロイするため。