### PR TITLE
basic認証設定のための環境変数明示化

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,6 +23,14 @@ namespace :deploy do
   end
 end
 
+set :default_env, {
+  rbenv_root: "/usr/local/rbenv",
+  path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
+  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"],
+  BASIC_AUTH_PASSWORD: ENV["BASIC_AUTH_PASSWORD"]
+}
+
+
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 


### PR DESCRIPTION
# WHAT
basic認証設定のための環境変数を明示化する。

# WHY
Capistranoを利用して自動デプロイを行う場合、環境変数を明示的に指定する必要があるため。