### PR TITLE
[WIP]items/new (商品出品ページ)画像以外のDBデータ保存&カテゴリ3段階表示

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,8 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery_ujs
+//= require jquery
 //= require rails-ujs
 //= require activestorage
 //= require jquery

--- a/app/assets/javascripts/category_form.js
+++ b/app/assets/javascripts/category_form.js
@@ -19,7 +19,6 @@ $(function(){
       var html = '<select><option value>--</option><option value="1">クロネコヤマト</option><option value="2">ゆうパック</option><option value="3">ゆうメール</option></select>'
       return html;}
 
-
   // #parent-formのid = 大カテゴリプルダウンが選択されたら発火
   $('#parent-form').on("change",function(){
 
@@ -29,7 +28,6 @@ $(function(){
   $('#grand_child').remove();
    // parentValueに、大カテゴリのhtmlの値を代入。
     var parentValue = document.getElementById("parent-form").value;
-
 
   $.ajax({
     //itemsファイルの中のsearch.json.jbuilderを読み込む
@@ -53,11 +51,8 @@ $(function(){
       $('#child').append(option);
     })
 
-
   $("#child").on("change", function(){
-
     var parentValue = document.getElementById("child").value;
-
   $.ajax({
     //itemsファイルの中のsearch.json.jbuilderを読み込む
     url:  '/items/search',
@@ -78,17 +73,9 @@ $(function(){
     //selectタブの中に、optionタブを表示。
       $('#grand_child').append(option);
     })
-
     })
-
   })
   })
   })
-
-
-
-
-
-
 });
 

--- a/app/assets/javascripts/category_form.js
+++ b/app/assets/javascripts/category_form.js
@@ -19,15 +19,15 @@ $(function(){
       var html = '<select><option value>--</option><option value="1">クロネコヤマト</option><option value="2">ゆうパック</option><option value="3">ゆうメール</option></select>'
       return html;}
 
-    // #parent-formのid = 大カテゴリプルダウンが選択されたら発火
+    //#parent-formのid = 大カテゴリプルダウンが選択されたら発火
     $('#parent-form').on("change",function(){
 
         //中カテゴリが1度選択されたらリセット
         $('#child').remove();
         //小カテゴリが1度選択されたらリセット
         $('#grand_child').remove();
-        // parentValueに、大カテゴリのhtmlの値を代入。
-          var parentValue = document.getElementById("parent-form").value;
+        //parentValueに、大カテゴリのhtmlの値を代入。
+        var parentValue = document.getElementById("parent-form").value;
 
         $.ajax({
           //itemsファイルの中のsearch.json.jbuilderを読み込む
@@ -37,7 +37,8 @@ $(function(){
           data: {parent_id: parentValue },
           dataType: 'json'
         })
-              //発火されたら、「中カテゴリのoptionタブhtml」を引数として受け取る
+
+        //発火されたら、「中カテゴリのoptionタブhtml」を引数として受け取る
         .done(function(cateChild) {
           //htmlは(中カテゴリのselectタブ。)
           var html = buildChild();
@@ -46,11 +47,12 @@ $(function(){
           //optionタブにそれぞれ、中カテゴリの値を入れる。
           cateChild.forEach(function(cateChild){
           //option = (中カテゴリの値)
-            var option = buildOption(cateChild);
+          var option = buildOption(cateChild);
           //selectタブの中に、optionタブを表示。
-            $('#child').append(option);
+          $('#child').append(option);
           })
 
+            //#childのid = 中カテゴリプルダウンが選択されたら発火
             $("#child").on("change", function(){
               var parentValue = document.getElementById("child").value;
                 $.ajax({
@@ -69,9 +71,9 @@ $(function(){
                   //optionタブにそれぞれ、中カテゴリの値を入れる。
                   cateChild.forEach(function(cateChild){
                   //option = (中カテゴリの値)
-                    var option = buildOption(cateChild);
+                  var option = buildOption(cateChild);
                   //selectタブの中に、optionタブを表示。
-                    $('#grand_child').append(option);
+                  $('#grand_child').append(option);
                   })
                 })
             })

--- a/app/assets/javascripts/category_form.js
+++ b/app/assets/javascripts/category_form.js
@@ -1,8 +1,12 @@
 $(function(){
-  //中カテゴリのhtml
+  //中カテゴリのselectタブのhtml
   function buildChild(){
-    var html =`<%= f.collection_select :category, @children, :id, :name,{prompt: "---"}, class: "select-default", id: "parent-form", name: 'item[category_ids][]' %>`
+    var html =`<select class="item-contents__item-about_box_condition_input" id="child" name="item[item_categories_attributes][0][category_id]"></select>`
     return html;}
+　//中カテゴリのoptionタブのhtml
+    function buildOption(cateChild){
+      var html = `<option value="${cateChild.id}">${cateChild.name}</option>`
+      return html;}
 
   // #parent-formのid = 大カテゴリプルダウンが選択されたら発火
   $('#parent-form').on("change",function(){
@@ -17,12 +21,20 @@ $(function(){
     data: {parent_id: parentValue },
     dataType: 'json'
   })
-    //発火されたら、
-  .done(function(data) {
-    //htmlは(中カテゴリのプルダウン。)
+    //発火されたら、「中カテゴリのoptionタブhtml」を引数として受け取る
+  .done(function(cateChild) {
+    console.log(cateChild);
+    //htmlは(中カテゴリのselectタブ。)
     var html = buildChild();
-    //hamlのselect-wrapクラスに、 htmlが現れる。(中カテゴリのプルダウン)
-    $('.select-wrap').append(html);
+    //hamlのselect-wrapクラスに、(中カテゴリのselectタブ)が現れる。
+    $('.select-wrap').append(html)
+    //optionタブにそれぞれ、中カテゴリの値を入れる。
+    cateChild.forEach(function(cateChild){
+     //option = (中カテゴリの値)
+      var option = buildOption(cateChild);
+    //selectタブの中に、optionタブを表示。
+      $('#child').append(option);
+    })
     })
 
     //失敗したら、エラーのアラート

--- a/app/assets/javascripts/category_form.js
+++ b/app/assets/javascripts/category_form.js
@@ -1,81 +1,81 @@
 $(function(){
-  //中カテゴリのselectタブのhtml
-  function buildChild(){
-    var html =`<select class="item-contents__item-about_box_condition_input" id="child" name="item[item_categories_attributes][0][category_id]"></select>`
-    return html;}
+    //中カテゴリのselectタブのhtml
+    function buildChild(){
+      var html =`<select class="item-contents__item-about_box_condition_input" id="child" name="item[item_categories_attributes][0][category_id]"></select>`
+      return html;}
 
     //小カテゴリのselectタブのhtml
-  function buildGrandChild(){
-    var html =`<select class="item-contents__item-about_box_condition_input" id="grand_child" name="item[item_categories_attributes][0][category_id]"></select>`
-    return html;}
+    function buildGrandChild(){
+      var html =`<select class="item-contents__item-about_box_condition_input" id="grand_child" name="item[item_categories_attributes][0][category_id]"></select>`
+      return html;}
 
-　//中カテゴリのoptionタブのhtml
+  　//中カテゴリのoptionタブのhtml
     function buildOption(cateChild){
       var html = `<option value="${cateChild.id}">${cateChild.name}</option>`
       return html;}
 
-  //配送箇所のselectタグとoptionタグのhtml
+    //配送箇所のselectタグとoptionタグのhtml
     function buildShippingMethod(){
       var html = '<select><option value>--</option><option value="1">クロネコヤマト</option><option value="2">ゆうパック</option><option value="3">ゆうメール</option></select>'
       return html;}
 
-  // #parent-formのid = 大カテゴリプルダウンが選択されたら発火
-  $('#parent-form').on("change",function(){
+    // #parent-formのid = 大カテゴリプルダウンが選択されたら発火
+    $('#parent-form').on("change",function(){
 
-  //中カテゴリが1度選択されたらリセット
-  $('#child').remove();
-  //小カテゴリが1度選択されたらリセット
-  $('#grand_child').remove();
-   // parentValueに、大カテゴリのhtmlの値を代入。
-    var parentValue = document.getElementById("parent-form").value;
+        //中カテゴリが1度選択されたらリセット
+        $('#child').remove();
+        //小カテゴリが1度選択されたらリセット
+        $('#grand_child').remove();
+        // parentValueに、大カテゴリのhtmlの値を代入。
+          var parentValue = document.getElementById("parent-form").value;
 
-  $.ajax({
-    //itemsファイルの中のsearch.json.jbuilderを読み込む
-    url: '/items/search',
-    type: "GET",
-    // 大カテゴリの値をparent_idという変数にする。この値をcontrollerで@childrenを定義することに使う。
-    data: {parent_id: parentValue },
-    dataType: 'json'
-  })
-    //発火されたら、「中カテゴリのoptionタブhtml」を引数として受け取る
-  .done(function(cateChild) {
-    //htmlは(中カテゴリのselectタブ。)
-    var html = buildChild();
-    //hamlのselect-wrapクラスに、(中カテゴリのselectタブ)が現れる。
-    $('.select-wrap').append(html)
-    //optionタブにそれぞれ、中カテゴリの値を入れる。
-    cateChild.forEach(function(cateChild){
-     //option = (中カテゴリの値)
-      var option = buildOption(cateChild);
-    //selectタブの中に、optionタブを表示。
-      $('#child').append(option);
-    })
+        $.ajax({
+          //itemsファイルの中のsearch.json.jbuilderを読み込む
+          url: '/items/search',
+          type: "GET",
+          // 大カテゴリの値をparent_idという変数にする。この値をcontrollerで@childrenを定義することに使う。
+          data: {parent_id: parentValue },
+          dataType: 'json'
+        })
+              //発火されたら、「中カテゴリのoptionタブhtml」を引数として受け取る
+        .done(function(cateChild) {
+          //htmlは(中カテゴリのselectタブ。)
+          var html = buildChild();
+          //hamlのselect-wrapクラスに、(中カテゴリのselectタブ)が現れる。
+          $('.select-wrap').append(html)
+          //optionタブにそれぞれ、中カテゴリの値を入れる。
+          cateChild.forEach(function(cateChild){
+          //option = (中カテゴリの値)
+            var option = buildOption(cateChild);
+          //selectタブの中に、optionタブを表示。
+            $('#child').append(option);
+          })
 
-  $("#child").on("change", function(){
-    var parentValue = document.getElementById("child").value;
-  $.ajax({
-    //itemsファイルの中のsearch.json.jbuilderを読み込む
-    url:  '/items/search',
-    type: "GET",
-    // 大カテゴリの値をparent_idという変数にする。この値をcontrollerで@childrenを定義することに使う。
-    data: {parent_id: parentValue },
-    dataType: 'json'
-  })
-  .done(function(cateChild) {
-    //htmlは(中カテゴリのselectタブ。)
-    var html = buildGrandChild();
-    //hamlのselect-wrapクラスに、(中カテゴリのselectタブ)が現れる。
-    $('.select-wrap').append(html)
-    //optionタブにそれぞれ、中カテゴリの値を入れる。
-    cateChild.forEach(function(cateChild){
-     //option = (中カテゴリの値)
-      var option = buildOption(cateChild);
-    //selectタブの中に、optionタブを表示。
-      $('#grand_child').append(option);
+            $("#child").on("change", function(){
+              var parentValue = document.getElementById("child").value;
+                $.ajax({
+                  //itemsファイルの中のsearch.json.jbuilderを読み込む
+                  url:  '/items/search',
+                  type: "GET",
+                  // 大カテゴリの値をparent_idという変数にする。この値をcontrollerで@childrenを定義することに使う。
+                  data: {parent_id: parentValue },
+                  dataType: 'json'
+                })
+                .done(function(cateChild) {
+                  //htmlは(中カテゴリのselectタブ。)
+                  var html = buildGrandChild();
+                  //hamlのselect-wrapクラスに、(中カテゴリのselectタブ)が現れる。
+                  $('.select-wrap').append(html)
+                  //optionタブにそれぞれ、中カテゴリの値を入れる。
+                  cateChild.forEach(function(cateChild){
+                  //option = (中カテゴリの値)
+                    var option = buildOption(cateChild);
+                  //selectタブの中に、optionタブを表示。
+                    $('#grand_child').append(option);
+                  })
+                })
+            })
+        })
     })
-    })
-  })
-  })
-  })
 });
 

--- a/app/assets/javascripts/category_form.js
+++ b/app/assets/javascripts/category_form.js
@@ -1,0 +1,33 @@
+$(function(){
+  //中カテゴリのhtml
+  function buildChild(){
+    var html =`<%= f.collection_select :category, @children, :id, :name,{prompt: "---"}, class: "select-default", id: "parent-form", name: 'item[category_ids][]' %>`
+    return html;}
+
+  // #parent-formのid = 大カテゴリプルダウンが選択されたら発火
+  $('#parent-form').on("change",function(){
+  // parentValueに、大カテゴリのhtmlの値を代入。
+    var parentValue = document.getElementById("parent-form").value;
+
+  $.ajax({
+    //itemsファイルの中のsearch.json.jbuilderを読み込む
+    url: '/items/search',
+    type: "GET",
+    // 大カテゴリの値をparent_idという変数にする。この値をcontrollerで@childrenを定義することに使う。
+    data: {parent_id: parentValue },
+    dataType: 'json'
+  })
+    //発火されたら、
+  .done(function(data) {
+    //htmlは(中カテゴリのプルダウン。)
+    var html = buildChild();
+    //hamlのselect-wrapクラスに、 htmlが現れる。(中カテゴリのプルダウン)
+    $('.select-wrap').append(html);
+    })
+
+    //失敗したら、エラーのアラート
+  .fail(function(){
+    alert('error');
+  })
+})
+});

--- a/app/assets/javascripts/category_form.js
+++ b/app/assets/javascripts/category_form.js
@@ -3,15 +3,33 @@ $(function(){
   function buildChild(){
     var html =`<select class="item-contents__item-about_box_condition_input" id="child" name="item[item_categories_attributes][0][category_id]"></select>`
     return html;}
+
+    //小カテゴリのselectタブのhtml
+  function buildGrandChild(){
+    var html =`<select class="item-contents__item-about_box_condition_input" id="grand_child" name="item[item_categories_attributes][0][category_id]"></select>`
+    return html;}
+
 　//中カテゴリのoptionタブのhtml
     function buildOption(cateChild){
       var html = `<option value="${cateChild.id}">${cateChild.name}</option>`
       return html;}
 
+  //配送箇所のselectタグとoptionタグのhtml
+    function buildShippingMethod(){
+      var html = '<select><option value>--</option><option value="1">クロネコヤマト</option><option value="2">ゆうパック</option><option value="3">ゆうメール</option></select>'
+      return html;}
+
+
   // #parent-formのid = 大カテゴリプルダウンが選択されたら発火
   $('#parent-form').on("change",function(){
-  // parentValueに、大カテゴリのhtmlの値を代入。
+
+  //中カテゴリが1度選択されたらリセット
+  $('#child').remove();
+  //小カテゴリが1度選択されたらリセット
+  $('#grand_child').remove();
+   // parentValueに、大カテゴリのhtmlの値を代入。
     var parentValue = document.getElementById("parent-form").value;
+
 
   $.ajax({
     //itemsファイルの中のsearch.json.jbuilderを読み込む
@@ -23,7 +41,6 @@ $(function(){
   })
     //発火されたら、「中カテゴリのoptionタブhtml」を引数として受け取る
   .done(function(cateChild) {
-    console.log(cateChild);
     //htmlは(中カテゴリのselectタブ。)
     var html = buildChild();
     //hamlのselect-wrapクラスに、(中カテゴリのselectタブ)が現れる。
@@ -35,11 +52,43 @@ $(function(){
     //selectタブの中に、optionタブを表示。
       $('#child').append(option);
     })
+
+
+  $("#child").on("change", function(){
+
+    var parentValue = document.getElementById("child").value;
+
+  $.ajax({
+    //itemsファイルの中のsearch.json.jbuilderを読み込む
+    url:  '/items/search',
+    type: "GET",
+    // 大カテゴリの値をparent_idという変数にする。この値をcontrollerで@childrenを定義することに使う。
+    data: {parent_id: parentValue },
+    dataType: 'json'
+  })
+  .done(function(cateChild) {
+    //htmlは(中カテゴリのselectタブ。)
+    var html = buildGrandChild();
+    //hamlのselect-wrapクラスに、(中カテゴリのselectタブ)が現れる。
+    $('.select-wrap').append(html)
+    //optionタブにそれぞれ、中カテゴリの値を入れる。
+    cateChild.forEach(function(cateChild){
+     //option = (中カテゴリの値)
+      var option = buildOption(cateChild);
+    //selectタブの中に、optionタブを表示。
+      $('#grand_child').append(option);
     })
 
-    //失敗したら、エラーのアラート
-  .fail(function(){
-    alert('error');
+    })
+
   })
-})
+  })
+  })
+
+
+
+
+
+
 });
+

--- a/app/assets/stylesheets/item/new.scss
+++ b/app/assets/stylesheets/item/new.scss
@@ -311,3 +311,22 @@ body{
   margin-top:8px;
   background-color: white;
 }
+.select-wrap{
+  select{
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  margin-bottom: 20px;
+  padding: 7px 30px 7px 10px;
+  font-size: 93%;
+  line-height: 1.1em;
+  border-radius: 5px;
+  height:50px;
+  width:400px;
+  border: solid 1px #ccc;
+  border-radius: 4px;
+  padding:10px 16px 8px 16px;
+  margin-top:8px;
+  background-color: white;
+  }
+}

--- a/app/assets/stylesheets/item/new.scss
+++ b/app/assets/stylesheets/item/new.scss
@@ -291,7 +291,23 @@ body{
   }
 }
 }
-single-container nav{
+.single-container nav{
   font-size:13px;
 }
-
+.select--booox{
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  margin-bottom: 20px;
+  padding: 7px 30px 7px 10px;
+  font-size: 93%;
+  line-height: 1.1em;
+  border-radius: 5px;
+  height:50px;
+  width:400px;
+  border: solid 1px #ccc;
+  border-radius: 4px;
+  padding:10px 16px 8px 16px;
+  margin-top:8px;
+  background-color: white;
+}

--- a/app/assets/stylesheets/item/new.scss
+++ b/app/assets/stylesheets/item/new.scss
@@ -114,9 +114,9 @@ body{
       border-bottom: solid 1px #eee;
     }
     &__item--detail{
-      height:310px;
+      min-height:310px;
       padding:40px;
-      border-bottom: solid 1px #eee;
+      overflow: auto;
       &__pulldown{
         width:400px;
         float:right;
@@ -145,6 +145,7 @@ body{
               padding:10px 16px 8px 16px;
               margin-top:8px;
               background-color: white;
+              margin-bottom:20px;
             }
             select::-ms-expand {
               display: none;
@@ -154,6 +155,7 @@ body{
       }
     }
     &__delivery{
+      border-top: solid 1px #eee;
       height:430px;
       padding:40px;
       border-bottom: solid 1px #eee;
@@ -201,6 +203,7 @@ body{
         height: 218px;
         width: 400px;
         float:right;
+        font-size:14px;
         &__price{
           height:70px;
           border-bottom: solid 1px #ccc;
@@ -222,6 +225,7 @@ body{
       height:350px;
       padding:40px;
       line-height:25px;
+      font-size:14px;
       a {
         text-decoration: none;
         color:#0099e8;
@@ -330,3 +334,4 @@ body{
   background-color: white;
   }
 }
+

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,7 +12,7 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
-    @parents = Category.all.order("id ASC").limit(13)
+    @parents = Category.order("id ASC").limit(13)
     @address = Address.new
   end
 
@@ -21,13 +21,8 @@ class ItemsController < ApplicationController
     redirect_to controller: :items, action: :index
   end
 
-
-
-
-
   def show
   end
-
 
   def search
     @children = Category.find(params[:parent_id]).children
@@ -36,7 +31,6 @@ class ItemsController < ApplicationController
       format.json
     end
   end
-
 
   private
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,7 +12,7 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
-    @parents = Category.find(1).siblings
+    @parents = Category.all.order("id ASC").limit(13)
     # @children = Category.find(1).children
     # @grandchild = Category.find(1).indirects
     # @price = Price.new
@@ -34,8 +34,11 @@ class ItemsController < ApplicationController
 
 
   def search
+    @children = Category.find(params[:parent_id]).children
+    # binding.pry
     respond_to do |format|
-      format.json {@children = Category.find(params[:parent_id]).children}
+      format.html
+      format.json
        #親ボックスのidから子ボックスのidの配列を作成してインスタンス変数で定義。search.json.jbuilderへ。
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,14 +34,17 @@ class ItemsController < ApplicationController
 
 
   def search
+    #親ボックスのidから子ボックスのidの配列を作成してインスタンス変数で定義。search.json.jbuilderへ。
     @children = Category.find(params[:parent_id]).children
-    # binding.pry
+    #子ボックスのidから孫ボックスのidの配列を作成してインスタンス変数で定義。search.json.jbuilderへ。
+    # @categories_grandchild = Category.find(params[:child_id]).children
+    # @grandchildren = Category.find(params[:child_id]).children
     respond_to do |format|
       format.html
       format.json
-       #親ボックスのidから子ボックスのidの配列を作成してインスタンス変数で定義。search.json.jbuilderへ。
     end
   end
+
 
   private
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,8 +13,6 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
     @parents = Category.all.order("id ASC").limit(13)
-    # @children = Category.find(1).children
-    # @grandchild = Category.find(1).indirects
     # @price = Price.new
     # @tax = @price * 0.1
     # @profit = @price * 0.9
@@ -34,11 +32,7 @@ class ItemsController < ApplicationController
 
 
   def search
-    #親ボックスのidから子ボックスのidの配列を作成してインスタンス変数で定義。search.json.jbuilderへ。
     @children = Category.find(params[:parent_id]).children
-    #子ボックスのidから孫ボックスのidの配列を作成してインスタンス変数で定義。search.json.jbuilderへ。
-    # @categories_grandchild = Category.find(params[:child_id]).children
-    # @grandchildren = Category.find(params[:child_id]).children
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,7 +17,7 @@ class ItemsController < ApplicationController
   end
 
   def create
-    Item.create(item_params)
+    Item.create!(item_params)
     redirect_to controller: :items, action: :index
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,8 +11,37 @@ class ItemsController < ApplicationController
   end
 
   def new
+    @item = Item.new
+    @parents = Category.find(1).siblings
+    # @children = Category.find(1).children
+    # @grandchild = Category.find(1).indirects
+    # @price = Price.new
+    # @tax = @price * 0.1
+    # @profit = @price * 0.9
   end
 
+  def create
+    Item.create!(item_params)
+    redirect_to controller: :items, action: :index
+  end
+
+
+
+
+
   def show
+  end
+
+
+  def search
+    respond_to do |format|
+      format.json {@children = Category.find(params[:parent_id]).children}
+       #親ボックスのidから子ボックスのidの配列を作成してインスタンス変数で定義。search.json.jbuilderへ。
+    end
+  end
+
+  private
+  def item_params
+    params.require(:item).permit(:name, :detail, :condition, :shipping_cost, :delivery_date, :price)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,9 +13,7 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
     @parents = Category.all.order("id ASC").limit(13)
-    # @price = Price.new
-    # @tax = @price * 0.1
-    # @profit = @price * 0.9
+    @address = Address.new
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,7 +17,7 @@ class ItemsController < ApplicationController
   end
 
   def create
-    Item.create!(item_params)
+    Item.create(item_params)
     redirect_to controller: :items, action: :index
   end
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,5 @@
 class Address < ApplicationRecord
   belongs_to :user
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,25 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
+      {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
+      {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
+      {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
+      {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
+      {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
+      {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
+      {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
+      {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
+      {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
+      {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
+      {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
+      {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
+      {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
+      {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
+      {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+  ]
+end
+
+class Item < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
+end

--- a/app/views/items/create.html.haml
+++ b/app/views/items/create.html.haml
@@ -1,0 +1,15 @@
+.single-container
+  %main.single-main
+    %section.single-container-section
+      .sell-modal
+        %h3.sell-modal-head 出品が完了しました
+        .sell-modal-body
+          %p.text-center
+            あなたが出品した商品は「出品した商品一覧」からいつでも見ることができます。
+            =link_to "続けて出品する","#"
+          %br/
+          %p.text-center
+            =link_to "商品ページへ行ってシェアする", "#"
+            %br/
+            %br/
+            =link_to "トップページへ戻る", "#"

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -37,6 +37,7 @@
               .single-main__section__item--detail__pulldown__one__tab
                 = f.collection_select :category, @parents, :id, :name,{prompt: "---"}, class: "select-default", id: "parent-form", name: 'item[category_ids][]'
               .select-wrap
+              .select-wrap2
           .single-main__section__item--detail__pulldown__one
             %label.normal-label 商品の状態
             %span.form-require 必須
@@ -51,7 +52,8 @@
               %span.form-require 必須
               .single-main__section__delivery__pulldown__one__tab
                 =f.label :shipping_cost do
-                  =f.select :shipping_cost, [["--", ""], ["送料込み(出品者負担)", "1"], ["着払い(購入者負担)", "2"]], {class: 'select--booox'}
+                  =f.select :shipping_cost, [["--", ""], ["送料込み(出品者負担)", "1"], ["着払い(購入者負担)", "2"]], id: "pulu"
+                  .pulu2
           .single-main__section__delivery__pulldown__one
             %label.normal-label 配送元の地域
             %span.form-require 必須

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,171 +1,147 @@
-!!!
-%html
-  %head
-    %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
-    %link{:href => "https://use.fontawesome.com/releases/v5.6.1/css/all.css", :rel => "stylesheet"}/
-    %title mercari
-
-    .single-container
-      %header.single-header
-        = image_tag('/images/mercari_logo_horizontal.png', size: "250x70")
-      %main.single-main
-        %section.single-main__section
-          .single-main__section__title
-            %h2.single-main__section__title__bar
-              商品の情報を入力
-          .single-main__section__picture
-            %label#large-label 出品画像
-            %span.form-require 必須
-            %p 最大10枚までアップロードできます
-            .single-main__section__picture__uploader
+.single-container
+  %header.single-header
+    -# = image_tag 'mercari_logo_horizontal.png', size: "250x70"
+  %main.single-main
+    = form_for(@item) do |f|
+      %section.single-main__section
+        .single-main__section__title
+          %h2.single-main__section__title__bar 商品の情報を入力
+        .single-main__section__picture
+          %label#large-label 出品画像
+          %span.form-require 必須
+          %p 最大10枚までアップロードできます
+          .single-main__section__picture__uploader
+            =label :images, "", for: "item_images" do
+              =f.file_field :images, class: "single", style: "display: none;"
               %p
                 ドラッグアンドドロップ
                 %br>/
                 またはクリックしてファイルをアップロード
-          .single-main__section__item--name
-            .form-group
-              %label.normal-label 商品名
-              %span.form-require 必須
-              %input.form{placeholder: "商品名(必須40文字まで)", value:""}/
-            .form-group
-              %label.normal-label 商品の説明
-              %span.form-require 必須
-              %textarea.form-detail{cols: "50", placeholder:"商品の説明必須1,00文字以内色、素材、重さ、定価、注意点など例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。合わせやすいのでおすすめです。", rows:"10", wrap: "soft"}
-          .single-main__section__item--detail
-            %h3.gray-title.detail-left 商品の詳細
-            .single-main__section__item--detail__pulldown
-              .single-main__section__item--detail__pulldown__one
-                %label.normal-label カテゴリー
-                %span.form-require 必須
-                .single-main__section__item--detail__pulldown__one__tab
-                  %select{name:"categoly",type: "text"}
-                    %option{value:"--"} --
-                    %option{value:"レディース"} レディース
-                    %option{value:"メンズ"} メンズ
-                    %option{value:"ベビー・キッズ"} ベビー・キッズ
-                    %option{value:"インテリア・住まい・小物"} インテリア・住まい・小物
-                    %option{value:"本・音楽・ゲーム"} 本・音楽・ゲーム
-                    %option{value:"おもちゃ・ホビー・グッズ"} おもちゃ・ホビー・グッズ
-                    %option{value:"コスメ・香水・美容"} コスメ・香水・美容
-                    %option{value:"家電・スマホ・カメラ"} 家電・スマホ・カメラ
-                    %option{value:"スポーツ・レジャー"} スポーツ・レジャー
-                    %option{value:"ハンドメイド"} ハンドメイド
-                    %option{value:"チケット"} チケット
-                    %option{value:"自動車・オートバイ"} 自動車・オートバイ
-                    %option{value:"その他"} その他
-                    %i.far.fa-angle-down
+        .single-main__section__item--name
+          .form-group
+            %label.normal-label 商品名
+            %span.form-require 必須
+            =f.label :name do
+              =f.text_field :name, class: "form", placeholder: "商品名（必須 40文字まで)"
+          .form-group
+            %label.normal-label 商品の説明
+            %span.form-require 必須
+            =f.label :detail do
+              =f.text_area :detail, class: "form-detail", cols: "50", rows:"10", wrap: "soft", placeholder: "商品の説明必須1,00文字以内色、素材、重さ、定価、注意点など例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。合わせやすいのでおすすめです。", value: ""
+        .single-main__section__item--detail
+          %h3.gray-title.detail-left 商品の詳細
+          .single-main__section__item--detail__pulldown
             .single-main__section__item--detail__pulldown__one
-              %label.normal-label 商品の状態
+              %label.normal-label カテゴリー
               %span.form-require 必須
               .single-main__section__item--detail__pulldown__one__tab
-                %select{name:"condeition",type: "text"}
-                  %option{value:"--"} --
-                  %option{value:"新品、未使用"} 新品、未使用
-                  %option{value:"未使用に近い"} 未使用に近い
-                  %option{value:"目立った傷や汚れなし"} 目立った傷や汚れなし
-                  %option{value:"やや傷や汚れあり"} やや傷や汚れあり
-                  %option{value:"傷や汚れあり"} 傷や汚れあり
-                  %option{value:"全体的に状態が悪い"} 全体的に状態が悪い
-          .single-main__section__delivery
-            %h3.gray-title 配送について
-            .single-main__section__delivery__pulldown
-              .single-main__section__delivery__pulldown__one
-                %label.normal-label 配送量の負担
-                %span.form-require 必須
-                .single-main__section__delivery__pulldown__one__tab
-                  %select{name:"send-fee",type: "text"}
-                    %option{value:"--"} --
-                    %option{value:"送料込み(出品者負担)"} 送料込み(出品者負担)
-                    %option{value:"着払い(購入者負担)"} 着払い(購入者負担)
+                = f.collection_select :category, @parents, :id, :name,{prompt: "---"}, class: "select-default", id: "parent-form", name: 'item[category_ids][]'
+              .select-wrap
+          .single-main__section__item--detail__pulldown__one
+            %label.normal-label 商品の状態
+            %span.form-require 必須
+            .single-main__section__item--detail__pulldown__one__tab
+              =f.label :condition do
+                =f.select :condition, [["--", ""], ["新品、未使用", "1"], ["未使用に近い", "2"], ["目立った傷や汚れなし", "3"], ["やや傷や汚れあり", "4"], ["傷や汚れあり", "5"], ["全体的に状態が悪い", "6"]], {class: 'select--booox'}
+        .single-main__section__delivery
+          %h3.gray-title 配送について
+          .single-main__section__delivery__pulldown
             .single-main__section__delivery__pulldown__one
-              %label.normal-label 配送元の地域
+              %label.normal-label 配送料の負担
               %span.form-require 必須
               .single-main__section__delivery__pulldown__one__tab
-                %select{name:"place",type: "text"}
-                  %option{value:"--"} --
-                  %option{value:"1"} 北海道
-                  %option{value:"2"} 青森県
-                  %option{value:"3"} 岩手県
-                  %option{value:"4"} 宮城県
-                  %option{value:"5"} 秋田県
-                  %option{value:"6"} 山形県
-                  %option{value:"7"} 福島県
-                  %option{value:"8"} 茨城県
-                  %option{value:"9"} 栃木県
-                  %option{value:"10"} 群馬県
-                  %option{value:"11"} 埼玉県
-                  %option{value:"12"} 千葉県
-                  %option{value:"13"} 東京都
-                  %option{value:"14"} 神奈川県
-                  %option{value:"15"} 新潟県
-                  %option{value:"16"} 富山県
-                  %option{value:"17"} 石川県
-                  %option{value:"18"} 福井県
-                  %option{value:"19"} 山梨県
-                  %option{value:"20"} 長野県
-                  %option{value:"21"} 岐阜県
-                  %option{value:"22"} 静岡県
-                  %option{value:"23"} 愛知県
-                  %option{value:"24"} 三重県
-                  %option{value:"25"} 滋賀県
-                  %option{value:"26"} 京都府
-                  %option{value:"27"} 大阪府
-                  %option{value:"28"} 兵庫県
-                  %option{value:"29"} 奈良県
-                  %option{value:"30"} 和歌山県
-                  %option{value:"31"} 鳥取県
-                  %option{value:"32"} 島根県
-                  %option{value:"33"} 岡山県
-                  %option{value:"34"} 広島県
-                  %option{value:"35"} 山口県
-                  %option{value:"36"} 徳島県
-                  %option{value:"37"} 香川県
-                  %option{value:"38"} 愛媛県
-                  %option{value:"39"} 高知県
-                  %option{value:"40"} 福岡県
-                  %option{value:"41"} 佐賀県
-                  %option{value:"42"} 長崎県
-                  %option{value:"43"} 熊本県
-                  %option{value:"44"} 大分県
-                  %option{value:"45"} 宮崎県
-                  %option{value:"46"} 鹿児島県
-                  %option{value:"47"} 沖縄県
-            .single-main__section__delivery__pulldown__one
-              %label.normal-label 発送までの日数
+                =f.label :shipping_cost do
+                  =f.select :shipping_cost, [["--", ""], ["送料込み(出品者負担)", "1"], ["着払い(購入者負担)", "2"]], {class: 'select--booox'}
+          .single-main__section__delivery__pulldown__one
+            %label.normal-label 配送元の地域
+            %span.form-require 必須
+            .single-main__section__delivery__pulldown__one__tab
+              %select{name:"place",type: "text"}
+                %option{value:""} --
+                %option{value:"1"} 北海道
+                %option{value:"2"} 青森県
+                %option{value:"3"} 岩手県
+                %option{value:"4"} 宮城県
+                %option{value:"5"} 秋田県
+                %option{value:"6"} 山形県
+                %option{value:"7"} 福島県
+                %option{value:"8"} 茨城県
+                %option{value:"9"} 栃木県
+                %option{value:"10"} 群馬県
+                %option{value:"11"} 埼玉県
+                %option{value:"12"} 千葉県
+                %option{value:"13"} 東京都
+                %option{value:"14"} 神奈川県
+                %option{value:"15"} 新潟県
+                %option{value:"16"} 富山県
+                %option{value:"17"} 石川県
+                %option{value:"18"} 福井県
+                %option{value:"19"} 山梨県
+                %option{value:"20"} 長野県
+                %option{value:"21"} 岐阜県
+                %option{value:"22"} 静岡県
+                %option{value:"23"} 愛知県
+                %option{value:"24"} 三重県
+                %option{value:"25"} 滋賀県
+                %option{value:"26"} 京都府
+                %option{value:"27"} 大阪府
+                %option{value:"28"} 兵庫県
+                %option{value:"29"} 奈良県
+                %option{value:"30"} 和歌山県
+                %option{value:"31"} 鳥取県
+                %option{value:"32"} 島根県
+                %option{value:"33"} 岡山県
+                %option{value:"34"} 広島県
+                %option{value:"35"} 山口県
+                %option{value:"36"} 徳島県
+                %option{value:"37"} 香川県
+                %option{value:"38"} 愛媛県
+                %option{value:"39"} 高知県
+                %option{value:"40"} 福岡県
+                %option{value:"41"} 佐賀県
+                %option{value:"42"} 長崎県
+                %option{value:"43"} 熊本県
+                %option{value:"44"} 大分県
+                %option{value:"45"} 宮崎県
+                %option{value:"46"} 鹿児島県
+                %option{value:"47"} 沖縄県
+          .single-main__section__delivery__pulldown__one
+            %label.normal-label 発送までの日数
+            %span.form-require 必須
+            .single-main__section__delivery__pulldown__one__tab
+              =f.label :delivery_date do
+                =f.select :delivery_date, [["--", ""], ["1~2日で発送", "1"], ["2~3日で発送", "2"], ["4~7日で発送", "3"]], {class: 'select--booox'}
+        .single-main__section__price
+          %h3.gray-title 販売価格(300〜9,999,999)
+          %ul.single-main__section__price__sell-form
+            %li.single-main__section__price__sell-form__price
+              %label.normal-label 価格
               %span.form-require 必須
-              .single-main__section__delivery__pulldown__one__tab
-                %select{name:"send-time",type: "text"}
-                  %option{value:"--"} --
-                  %option{value:"1~2日で発送"} 1~2日で発送
-                  %option{value:"2~3日で発送"} 2~3日で発送
-                  %option{value:"4~7日で発送"} 4~7日で発送
-          .single-main__section__price
-            %h3.gray-title 販売価格(300〜9,999,999)
-            %ul.single-main__section__price__sell-form
-              %li.single-main__section__price__sell-form__price
-                %label.normal-label 価格
-                %span.form-require 必須
-                .price-right
-                  ¥
-                  %input.form-price{placeholder: "例）300", value: ""}/
-              %li.single-main__section__price__sell-form__margin
-                販売手数料(10%)
-              %li.single-main__section__price__sell-form__profit
-                %label#large-label 販売利益
-          .single-main__section__exhibition
-            %p
-              = link_to "禁止されている出品、行為", "#"
-              を必ずご確認ください。またブランド品でシリアルナンバー等がある場合はご記載ください。
-              = link_to "偽ブランドの販売", "#"
-              は犯罪であり処罰される可能性があります。また、出品を持ちまして
-              = link_to "加盟店規約", "#"
-              に同意したことになります。
-            .single-main__section__exhibition__button
-              %button.single-main__section__exhibition__button__exhibition 出品する
-              %button.single-main__section__exhibition__button__return もどる
-      %footer.single-footer
-        .single-footer__section
-          %nav プライバシーポリシー メルカリ利用規約 特定商取引に関する表記
-          .single-footer__section__img
-            = image_tag('/images/mercari_logo_vertical.png', size: "88x85")
-          %p.single-footer__right @ 2019 Mercari
+              .price-right
+                ¥
+                =f.label :price do
+                  =f.text_field :price, class: "form-price", placeholder: "例）300", value: ""
+            %li.single-main__section__price__sell-form__margin
+              販売手数料(10%)
+            %li.single-main__section__price__sell-form__profit
+              %label#large-label 販売利益
+        .single-main__section__exhibition
+          %p
+            = link_to "禁止されている出品、行為", "#"
+            を必ずご確認ください。またブランド品でシリアルナンバー等がある場合はご記載ください。
+            = link_to "偽ブランドの販売", "#"
+            は犯罪であり処罰される可能性があります。また、出品を持ちまして
+            = link_to "加盟店規約", "#"
+            に同意したことになります。
+          .single-main__section__exhibition__button
+            = f.submit "出品する" , class: "single-main__section__exhibition__button__exhibition"
+            %button.single-main__section__exhibition__button__return もどる
+
+    %footer.single-footer
+      .single-footer__section
+        %nav プライバシーポリシー メルカリ利用規約 特定商取引に関する表記
+        .single-footer__section__img
+          -# = image_tag 'mercari_logo_vertical', size: "88x85"
+        %p.single-footer__right @ 2019 Mercari
+
+

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,6 +1,6 @@
 .single-container
   %header.single-header
-    -# = image_tag 'mercari_logo_horizontal.png', size: "250x70"
+    = image_tag('/images/mercari_logo_horizontal.png', size: "250x70")
   %main.single-main
     = form_for(@item) do |f|
       %section.single-main__section
@@ -95,7 +95,7 @@
       .single-footer__section
         %nav プライバシーポリシー メルカリ利用規約 特定商取引に関する表記
         .single-footer__section__img
-          -# = image_tag 'mercari_logo_vertical', size: "88x85"
+          = image_tag('/images/mercari_logo_vertical.png', size: "88x85")
         %p.single-footer__right @ 2019 Mercari
 
 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -58,55 +58,7 @@
             %label.normal-label 配送元の地域
             %span.form-require 必須
             .single-main__section__delivery__pulldown__one__tab
-              %select{name:"place",type: "text"}
-                %option{value:""} --
-                %option{value:"1"} 北海道
-                %option{value:"2"} 青森県
-                %option{value:"3"} 岩手県
-                %option{value:"4"} 宮城県
-                %option{value:"5"} 秋田県
-                %option{value:"6"} 山形県
-                %option{value:"7"} 福島県
-                %option{value:"8"} 茨城県
-                %option{value:"9"} 栃木県
-                %option{value:"10"} 群馬県
-                %option{value:"11"} 埼玉県
-                %option{value:"12"} 千葉県
-                %option{value:"13"} 東京都
-                %option{value:"14"} 神奈川県
-                %option{value:"15"} 新潟県
-                %option{value:"16"} 富山県
-                %option{value:"17"} 石川県
-                %option{value:"18"} 福井県
-                %option{value:"19"} 山梨県
-                %option{value:"20"} 長野県
-                %option{value:"21"} 岐阜県
-                %option{value:"22"} 静岡県
-                %option{value:"23"} 愛知県
-                %option{value:"24"} 三重県
-                %option{value:"25"} 滋賀県
-                %option{value:"26"} 京都府
-                %option{value:"27"} 大阪府
-                %option{value:"28"} 兵庫県
-                %option{value:"29"} 奈良県
-                %option{value:"30"} 和歌山県
-                %option{value:"31"} 鳥取県
-                %option{value:"32"} 島根県
-                %option{value:"33"} 岡山県
-                %option{value:"34"} 広島県
-                %option{value:"35"} 山口県
-                %option{value:"36"} 徳島県
-                %option{value:"37"} 香川県
-                %option{value:"38"} 愛媛県
-                %option{value:"39"} 高知県
-                %option{value:"40"} 福岡県
-                %option{value:"41"} 佐賀県
-                %option{value:"42"} 長崎県
-                %option{value:"43"} 熊本県
-                %option{value:"44"} 大分県
-                %option{value:"45"} 宮崎県
-                %option{value:"46"} 鹿児島県
-                %option{value:"47"} 沖縄県
+              = f.collection_select :shipping_source, Prefecture.all, :id, :name,{prompt: "---"}
           .single-main__section__delivery__pulldown__one
             %label.normal-label 発送までの日数
             %span.form-require 必須

--- a/app/views/items/search.json.jbuilder
+++ b/app/views/items/search.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @children do |child|
+  json.id child.id
+  json.name child.name
+end

--- a/app/views/items/search.json.jbuilder
+++ b/app/views/items/search.json.jbuilder
@@ -1,4 +1,4 @@
-json.array! @children do |child|
-  json.id child.id
-  json.name child.name
+json.array! @children do |cateChild|
+  json.id cateChild.id
+  json.name cateChild.name
 end

--- a/app/views/items/search.json.jbuilder
+++ b/app/views/items/search.json.jbuilder
@@ -2,8 +2,3 @@ json.array! @children do |cateChild|
   json.id cateChild.id
   json.name cateChild.name
 end
-
-# json.array! @grandchildren do |cateGrandChild|
-#   json.id cateGrandChild.id
-#   json.name cateGrandChild.name
-# end

--- a/app/views/items/search.json.jbuilder
+++ b/app/views/items/search.json.jbuilder
@@ -2,3 +2,8 @@ json.array! @children do |cateChild|
   json.id cateChild.id
   json.name cateChild.name
 end
+
+# json.array! @grandchildren do |cateGrandChild|
+#   json.id cateGrandChild.id
+#   json.name cateGrandChild.name
+# end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,10 @@ Rails.application.routes.draw do
   get 'credit/new'
   get 'credit/index'
   get 'purchase/new'
-  get 'items/index'
-  get 'items/new'
+  get 'items/index' => 'items#index'
+  get 'items/new' => 'items#new'
+  get 'items/new' => 'items#search'
+  post 'items' => 'items#create'
   get 'items/show'
 
   resources :categories, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,11 +15,20 @@ Rails.application.routes.draw do
   get 'credit/new'
   get 'credit/index'
   get 'purchase/new'
-  get 'items/index' => 'items#index'
-  get 'items/new' => 'items#new'
-  get 'items/search', to: 'items#search'
-  post 'items' => 'items#create'
-  get 'items/show'
+
+  resources :items, only: [:index, :new, :create, :show] do
+    collection do
+      get 'search'
+    end
+  end
+
+  # get 'items/index' => 'items#index'
+  # get 'items/new' => 'items#new'
+
+  # get 'items/search', to: 'items#search'
+  # post 'items' => 'items#create'
+
+  # get 'items/show'
 
   resources :categories, only: [:index, :show]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   get 'purchase/new'
   get 'items/index' => 'items#index'
   get 'items/new' => 'items#new'
-  get 'items/new' => 'items#search'
+  get 'items/search', to: 'items#search'
   post 'items' => 'items#create'
   get 'items/show'
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,7 +89,7 @@ man_bag.children.create([{name: "ショルダーバッグ"},{name: "トートバ
 man_suit = man.children.create(name: "スーツ")
 man_suit.children.create([{name: "スーツジャケット"},{name: "スーツベスト"},{name: "スラックス"},{name: "セットアップ"},{name: "その他"}])
 
-man_hat = man.children.create(name: "帽子") 
+man_hat = man.children.create(name: "帽子")
 man_hat.children.create([{name: "キャップ"},{name: "ハット"},{name: "ニットキャップ/ビーニー"},{name: "ハンチング/ベレー帽"},{name: "キャスケット"},{name: "サンバイザー"},{name: "その他"}])
 
 man_accessories = man.children.create(name: "アクセサリー")


### PR DESCRIPTION
#WHAT
items/new (商品出品ページ)において、下記の実装を行った。
(1)画像以外のデータDBへの保存
(2)カテゴリ3段階表示
https://gyazo.com/dc633a36538bbff87522099d84305d7f

#WHY
(1)「商品出品情報をDBに登録」　→　DBのものを表示(商品詳細ページやトップページ)の一連の流れを、始めに完成させることで、ページ全体の動き(チームの実装の一連の流れ)を把握できるようにするため。

(2)カテゴリ3段階表示の実装=「DBのデータを取り出し、ビューに動きをつける非同期通信を実装」を先に行い、仕組みを理解しておくことで、他のパーツにおいての「javascriptの実装」や、「DBのデータの取り出し」の実装をスムーズにするため。