### PR TITLE
パンくずリストの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,5 @@ gem "jquery-rails"
 
 gem 'ancestry'
 gem 'ransack'
+
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.1)
       temple (>= 0.8.0)
       tilt
@@ -362,6 +364,7 @@ DEPENDENCIES
   dropzonejs-rails
   factory_bot_rails
   faker
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -316,3 +316,36 @@
     }
   }
 }
+
+.link__list {
+  position: relative;
+  border-top: 1px solid #eee;
+  box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
+  background: #fff;
+  ul {
+    width: 1020px;
+    overflow: visible;
+    margin: 0 auto;
+    padding: 16px 0;
+    white-space: normal;
+    font-size: 0;
+    li {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      display: inline-block;
+      font-size: 14px;
+      line-height: 1.2;
+      a {
+        color: #333;
+      }
+      span:last-child {
+        font-weight: 600;
+      }
+    }
+  }
+}
+.gretel__icon {
+  margin: 0 8px;
+  font-size: 14px;
+  color: #888;
+}

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,4 +1,9 @@
 = render partial: "layouts/header"
+.link__list
+  %ul
+    %li
+      - breadcrumb :category_index
+      = breadcrumbs separator: " &rsaquo; "
 = render partial: "layouts/button"
 .categories
   .categries__inner

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,4 +1,9 @@
 = render partial: "layouts/header"
+.link__list
+  %ul
+    %li
+      - breadcrumb :category, @category
+      = breadcrumbs separator: " #{content_tag(:i, '', :class=>'fas fa-angle-right gretel__icon')} "
 = render partial: "layouts/button"
 .categories__show.clearfix
   .categories__show__inner  

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,16 @@
+crumb :root do
+  link "メルカリ", root_path
+end
+
+crumb :category_index do
+  link "カテゴリー一覧", categories_path
+  parent :root
+end
+
+crumb :category do |category|
+  link category.name, category_path(category.id)
+
+  if category.parent.present?
+    parent category.parent
+  end
+end


### PR DESCRIPTION
# WHAT
gem「gretel」の追加
パンくずリストの実装
現在のページから親ページに戻れるようにリンクをつける

# WHY
辿ってきたページが視覚化できるためユーザビリティの向上に繋がる
SEOに効果的

# 補足
現在はルーティングが整っているカテゴリー関連のページのみ実装しています。
他ページもルーティングが整い次第パンくずリストに追加していく予定です。

[![Image from Gyazo](https://i.gyazo.com/a56b056ac8b09e3b0166c29238b732da.png)](https://gyazo.com/a56b056ac8b09e3b0166c29238b732da)
[![Image from Gyazo](https://i.gyazo.com/25d98a476035c69656f7bce90556bfb8.png)](https://gyazo.com/25d98a476035c69656f7bce90556bfb8)