### PR TITLE
password digest columnの見直し

### DIFF
--- a/db/migrate/20190624060537_remove_column_from_users.rb
+++ b/db/migrate/20190624060537_remove_column_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveColumnFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :password, :string
+    remove_column :users, :password_confirmation, :string
+  end
+end

--- a/db/migrate/20190624060946_add_password_digest_to_users.rb
+++ b/db/migrate/20190624060946_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_19_080302) do
+ActiveRecord::Schema.define(version: 2019_06_24_060946) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "postal"
@@ -159,8 +159,7 @@ ActiveRecord::Schema.define(version: 2019_06_19_080302) do
     t.string "nickname"
     t.text "avater_image"
     t.string "email"
-    t.string "password"
-    t.string "password_confirmation"
+    t.string "password_digest"
   end
 
   add_foreign_key "addresses", "users"


### PR DESCRIPTION
# WHAT
password digest columnの見直し。

# WHY
テーブルにpassword digestが存在し、migrationファイルでは、password, password confirmationが実行されており、本番環境でエラーが発生していたため。
